### PR TITLE
Fix random contention bug

### DIFF
--- a/src/main/java/com/eaio/uuid/UUIDGen.java
+++ b/src/main/java/com/eaio/uuid/UUIDGen.java
@@ -40,6 +40,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.Random;
 
 import com.eaio.util.lang.Hex;
 
@@ -173,6 +174,7 @@ public final class UUIDGen {
 
         }
 
+        Random r = new Random();
         if (macAddress != null) {
             clockSeqAndNode |= Hex.parseLong(macAddress);
         }
@@ -185,13 +187,13 @@ public final class UUIDGen {
                 clockSeqAndNode |= local[3] & 0xFF;
             }
             catch (UnknownHostException ex) {
-                clockSeqAndNode |= (long) (Math.random() * 0x7FFFFFFF);
+                clockSeqAndNode |= (long) (r.nextDouble() * 0x7FFFFFFF);
             }
         }
 
         // Skip the clock sequence generation process and use random instead.
 
-        clockSeqAndNode |= (long) (Math.random() * 0x3FFF) << 48;
+        clockSeqAndNode |= (long) (r.nextDouble() * 0x3FFF) << 48;
 
     }
 


### PR DESCRIPTION
In UUIDGen.java, Math.random() is used for random number generation. 
According to[ Java API ](http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#random--), it's suggested that each thread has their own random number generator to reduce contention.
The increasing in contention might have a significant effect since the random number generation is 
in thread implementation. 
This pull request improves the condition by replacing `Math.random()` with `Random.nextDouble()`.
